### PR TITLE
fix: migrate to Node16 module resolution to fix ES module imports

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,8 @@ This is a TypeScript project using modern best practices with ES modules, pnpm p
 ## Technology Stack
 
 - **TypeScript**: Strict mode enabled with modern ES2022+ features
+  - Uses Node16 module resolution for proper ES module support
+  - All relative imports require `.js` extensions
 - **Package Manager**: pnpm (required)
 - **Build Tool**: TypeScript Compiler (tsc)
 - **Testing**: Vitest with coverage support
@@ -31,6 +33,9 @@ This is a TypeScript project using modern best practices with ES modules, pnpm p
 ### TypeScript
 
 - Always use ES modules (`import`/`export`)
+- **All relative imports MUST include `.js` extensions** (e.g., `'./types.js'`, not `'./types'`)
+  - This is required for Node16 module resolution
+  - TypeScript will correctly map `.js` to `.ts` files during compilation
 - Enable strict type checking
 - Prefer type inference but add explicit return types for exported functions
 - Use `type` imports when importing only types

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 samples/temp/
+.DS_Store

--- a/__tests__/writers/csv/CsvWriter.test.ts
+++ b/__tests__/writers/csv/CsvWriter.test.ts
@@ -40,7 +40,6 @@ describe('CsvWriter', () => {
       };
 
       // Act & Assert
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       expect(() => new CsvWriter(options as any)).toThrow('Invalid writer type for CsvWriter');
     });
 

--- a/__tests__/writers/json/JsonWriter.test.ts
+++ b/__tests__/writers/json/JsonWriter.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -41,7 +40,6 @@ describe('JsonWriter', () => {
       };
 
       // Act & Assert
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       expect(() => new JsonWriter(options as any)).toThrow('Invalid writer type for JsonWriter');
     });
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,17 @@ export default [
     },
   },
   {
+    files: ['__tests__/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-construction': 'off',
+    },
+  },
+  {
     files: ['samples/**/*.ts'],
     rules: {
       'no-console': 'off',
@@ -78,6 +89,7 @@ export default [
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scottluskcis/outport",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Tool for exporting data to a format that can be used for reporting such as CSV, JSON, etc.",
   "type": "module",
   "main": "./dist/index.js",

--- a/samples/01-basic-csv-export.ts
+++ b/samples/01-basic-csv-export.ts
@@ -7,7 +7,7 @@
  * Run: npx tsx samples/01-basic-csv-export.ts
  */
 
-import { outport } from '../src/index';
+import { outport } from '../src/index.js';
 import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';

--- a/samples/02-basic-json-export.ts
+++ b/samples/02-basic-json-export.ts
@@ -7,7 +7,7 @@
  * Run: npx tsx samples/02-basic-json-export.ts
  */
 
-import { outport } from '../src/index';
+import { outport } from '../src/index.js';
 import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';

--- a/samples/03-csv-custom-config.ts
+++ b/samples/03-csv-custom-config.ts
@@ -10,7 +10,7 @@
  * Run: npx tsx samples/03-csv-custom-config.ts
  */
 
-import { outport } from '../src/index';
+import { outport } from '../src/index.js';
 import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';

--- a/samples/04-progress-tracking.ts
+++ b/samples/04-progress-tracking.ts
@@ -7,7 +7,7 @@
  * Run: npx tsx samples/04-progress-tracking.ts
  */
 
-import { outport } from '../src/index';
+import { outport } from '../src/index.js';
 import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';

--- a/samples/05-data-transformation.ts
+++ b/samples/05-data-transformation.ts
@@ -7,7 +7,7 @@
  * Run: npx tsx samples/05-data-transformation.ts
  */
 
-import { outport } from '../src/index';
+import { outport } from '../src/index.js';
 import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';

--- a/src/builder/OutportBuilder.ts
+++ b/src/builder/OutportBuilder.ts
@@ -5,8 +5,8 @@ import type {
   CsvConfig,
   JsonConfig,
   Result,
-} from '../types';
-import { WriterFactory } from '../writers/WriterFactory';
+} from '../types.js';
+import { WriterFactory } from '../writers/WriterFactory.js';
 import type {
   BeforeWriteHook,
   AfterWriteHook,
@@ -14,9 +14,9 @@ import type {
   ErrorHook,
   CompleteHook,
   LifecycleHooks,
-} from './hooks';
-import { ValidationError } from '../errors';
-import { StreamingWriter } from '../streaming/StreamingWriter';
+} from './hooks.js';
+import { ValidationError } from '../errors.js';
+import { StreamingWriter } from '../streaming/StreamingWriter.js';
 
 /**
  * Fluent builder for creating and configuring data writers.

--- a/src/builder/hooks.ts
+++ b/src/builder/hooks.ts
@@ -1,4 +1,4 @@
-import type { Result } from '../types';
+import type { Result } from '../types.js';
 
 /**
  * Hook called before data is written.

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -1,4 +1,4 @@
-export { OutportBuilder } from './OutportBuilder';
+export { OutportBuilder } from './OutportBuilder.js';
 export type {
   BeforeWriteHook,
   AfterWriteHook,
@@ -6,4 +6,4 @@ export type {
   ErrorHook,
   CompleteHook,
   LifecycleHooks,
-} from './hooks';
+} from './hooks.js';

--- a/src/convenience/factory.ts
+++ b/src/convenience/factory.ts
@@ -1,4 +1,4 @@
-import { OutportBuilder } from '../builder/OutportBuilder';
+import { OutportBuilder } from '../builder/OutportBuilder.js';
 
 /**
  * Creates a new fluent builder for configuring and executing data exports.

--- a/src/convenience/index.ts
+++ b/src/convenience/index.ts
@@ -1,1 +1,1 @@
-export { outport } from './factory';
+export { outport } from './factory.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export type {
   JsonConfig,
   Result,
   FileWriter,
-} from './types';
+} from './types.js';
 
 // Export errors
 export {
@@ -19,18 +19,18 @@ export {
   JsonFormattingError,
   FileWriteError,
   HeaderInitializationError,
-} from './errors';
+} from './errors.js';
 
 // Export writers
-export { CsvWriter } from './writers/csv/CsvWriter';
-export { JsonWriter } from './writers/json/JsonWriter';
-export { WriterFactory } from './writers/WriterFactory';
+export { CsvWriter } from './writers/csv/CsvWriter.js';
+export { JsonWriter } from './writers/json/JsonWriter.js';
+export { WriterFactory } from './writers/WriterFactory.js';
 
 // Export file writer implementation
-export { NodeFileWriter } from './io/FileWriter';
+export { NodeFileWriter } from './io/FileWriter.js';
 
 // Export builder API
-export { OutportBuilder } from './builder';
+export { OutportBuilder } from './builder/index.js';
 export type {
   BeforeWriteHook,
   AfterWriteHook,
@@ -38,11 +38,11 @@ export type {
   ErrorHook,
   CompleteHook,
   LifecycleHooks,
-} from './builder';
+} from './builder/index.js';
 
 // Export convenience functions
-export { outport } from './convenience';
+export { outport } from './convenience/index.js';
 
 // Export streaming utilities
-export { StreamingWriter, BatchProcessor } from './streaming';
-export type { StreamingOptions } from './streaming';
+export { StreamingWriter, BatchProcessor } from './streaming/index.js';
+export type { StreamingOptions } from './streaming/index.js';

--- a/src/io/FileWriter.ts
+++ b/src/io/FileWriter.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
-import type { FileWriter as IFileWriter, Result } from '../types';
-import { FileWriteError } from '../errors';
+import type { FileWriter as IFileWriter, Result } from '../types.js';
+import { FileWriteError } from '../errors.js';
 
 /**
  * Default file writer implementation using Node.js fs module.

--- a/src/streaming/StreamingWriter.ts
+++ b/src/streaming/StreamingWriter.ts
@@ -1,6 +1,6 @@
-import type { OutportWriter, Result } from '../types';
-import { BatchProcessor } from './BatchProcessor';
-import type { ProgressHook } from '../builder/hooks';
+import type { OutportWriter, Result } from '../types.js';
+import { BatchProcessor } from './BatchProcessor.js';
+import type { ProgressHook } from '../builder/hooks.js';
 
 /**
  * Options for streaming write operations.

--- a/src/streaming/index.ts
+++ b/src/streaming/index.ts
@@ -1,3 +1,3 @@
-export { StreamingWriter } from './StreamingWriter';
-export { BatchProcessor } from './BatchProcessor';
-export type { StreamingOptions } from './StreamingWriter';
+export { StreamingWriter } from './StreamingWriter.js';
+export { BatchProcessor } from './BatchProcessor.js';
+export type { StreamingOptions } from './StreamingWriter.js';

--- a/src/writers/WriterFactory.ts
+++ b/src/writers/WriterFactory.ts
@@ -1,7 +1,7 @@
-import type { OutportWriter, WriterConfig, FileWriter } from '../types';
-import { CsvWriter } from './csv/CsvWriter';
-import { JsonWriter } from './json/JsonWriter';
-import { ValidationError } from '../errors';
+import type { OutportWriter, WriterConfig, FileWriter } from '../types.js';
+import { CsvWriter } from './csv/CsvWriter.js';
+import { JsonWriter } from './json/JsonWriter.js';
+import { ValidationError } from '../errors.js';
 
 /**
  * Factory for creating data writer instances.

--- a/src/writers/csv/CsvHeaderManager.ts
+++ b/src/writers/csv/CsvHeaderManager.ts
@@ -1,5 +1,5 @@
-import type { CsvConfig, Result } from '../../types';
-import { HeaderInitializationError } from '../../errors';
+import type { CsvConfig, Result } from '../../types.js';
+import { HeaderInitializationError } from '../../errors.js';
 
 /**
  * Manages CSV header initialization and key determination

--- a/src/writers/csv/CsvWriter.ts
+++ b/src/writers/csv/CsvWriter.ts
@@ -1,8 +1,8 @@
-import type { OutportWriter, WriterOptions, Result, FileWriter } from '../../types';
-import { ValidationError, CsvFormattingError } from '../../errors';
-import { NodeFileWriter } from '../../io/FileWriter';
-import { CsvFormatter } from './CsvFormatter';
-import { CsvHeaderManager } from './CsvHeaderManager';
+import type { OutportWriter, WriterOptions, Result, FileWriter } from '../../types.js';
+import { ValidationError, CsvFormattingError } from '../../errors.js';
+import { NodeFileWriter } from '../../io/FileWriter.js';
+import { CsvFormatter } from './CsvFormatter.js';
+import { CsvHeaderManager } from './CsvHeaderManager.js';
 
 /**
  * CSV Writer for exporting data to CSV files.

--- a/src/writers/json/JsonFormatter.ts
+++ b/src/writers/json/JsonFormatter.ts
@@ -1,4 +1,4 @@
-import { JsonFormattingError } from '../../errors';
+import { JsonFormattingError } from '../../errors.js';
 
 /**
  * Handles JSON formatting logic - converting data to properly formatted JSON strings.

--- a/src/writers/json/JsonWriter.ts
+++ b/src/writers/json/JsonWriter.ts
@@ -1,7 +1,7 @@
-import type { OutportWriter, WriterOptions, Result, FileWriter } from '../../types';
-import { ValidationError, JsonFormattingError } from '../../errors';
-import { NodeFileWriter } from '../../io/FileWriter';
-import { JsonFormatter } from './JsonFormatter';
+import type { OutportWriter, WriterOptions, Result, FileWriter } from '../../types.js';
+import { ValidationError, JsonFormattingError } from '../../errors.js';
+import { NodeFileWriter } from '../../io/FileWriter.js';
+import { JsonFormatter } from './JsonFormatter.js';
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     /* Language and Environment */
     "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "Node16",
+    "moduleResolution": "node16",
 
     /* Emit */
     "declaration": true,


### PR DESCRIPTION
- Switch from bundler to node16 moduleResolution
- Add .js extensions to all relative imports in source files
- Update samples and documentation to reflect changes
- Fix ESLint configuration for test files
- Update copilot-instructions.md with Node16 requirements

Fixes ERR_MODULE_NOT_FOUND errors when consuming package